### PR TITLE
补充 AS2 字节码与 TS→AS2 基建可行性备忘

### DIFF
--- a/docs/AS2字节码优化候选普查备忘-2026-07-18.md
+++ b/docs/AS2字节码优化候选普查备忘-2026-07-18.md
@@ -1,0 +1,398 @@
+# AS2 字节码优化候选普查备忘（2026-07-18）
+
+> **文档角色**：只读研究结果与后续施工交接；非 canonical 规范。
+>
+> **状态**：候选普查完成，尚未进入任何字节码施工。
+>
+> **代码基线**：`fd6e3e6e424d69319e867a5d0dd31887f38df664`。
+>
+> **复核日期**：2026-07-18。
+>
+> **证据边界**：本轮做了源码、测试资产、已有 SWF 静态产物和架构文档审计；没有运行 Flash CS6 编译，没有取得新的生产播放器场景 profile，也没有声称任何候选已获得性能收益。本文的生产播放器特指仓库根目录 `Adobe Flash Player 20.exe` standalone；CS6 Test Movie 只能作为编译/smoke 环境，不能替代生产播放器结论。
+>
+> **关联研究**：若要评估 TS 双端生成与编译器路线，转到 [`TS到AS2编译基建可行性备忘-2026-07-18.md`](TS到AS2编译基建可行性备忘-2026-07-18.md)。
+
+## 1. 结论
+
+值得把研究上升为备忘，但不值得把“手写 AVM1/PCode”扩张成一般性的 AS2 优化方式。
+
+当前项目确实存在一小类适合继续筛选的内核：其中一部分调用覆盖广或位于战斗帧链，另一部分生产覆盖不高、但算法边界和 oracle 很强，可用于验证工具链。它们都只能先做源码实现与字节码实现的同输入双跑，再由生产播放器的代表场景实测决定是否保留。
+
+同时，多数看起来“底层”的 class 并不满足这些条件：有的生产调用很少，有的时间花在 MovieClip、动态属性、回调或分配上，有的已经手工内联到很深，剩余字节码空间很小。对这些 class 直接改写 PCode，维护和静默误编译风险会大于可预期收益。
+
+本轮建议的首批 5 个内核是：
+
+1. `TimSort.sortIndirect` 的固定数值 key 路径，作为高质量工具与测量对照组；
+2. `LinearCongruentialEngine` 的固定算法状态转移与批量取样；
+3. `BulletQueueProcessor` / `SortedUnitCache` 中可抽出的有序区间扫描窗口；
+4. `RayCollider` 的 slab 窄相，必要时再扩到 `PolygonCollider` 的 SAT 前半段；
+5. `SpatialHashGrid` 的坐标到 cell 与查询扫描，仅作低覆盖强-oracle PoC，先测真实武器场景。
+
+排序不是“预计收益从高到低”的承诺，而是当前最适合建立实验闭环的顺序。第 2、3 项在补齐 oracle 前不得改生产路径；第 1 项预计边际收益有限，但最适合验证字节码工具和测量方法是否可信；第 5 项若真实武器场景占比不足，只保留作工具 PoC，不进入生产优化。
+
+## 2. 本备忘回答什么
+
+本备忘回答：
+
+- 哪些 class、全局函数与调用链可能值得做字节码级 A/B；
+- 热点判断目前有什么证据，哪些仍只是成本假设；
+- 各候选的正确性 oracle 是否足够；
+- 可预期的字节码优化空间和语义风险；
+- 哪些对象应暂缓或淘汰；
+- 下次恢复施工时，第一批实验应切到多小。
+
+本备忘不授权：
+
+- 手工修改任何 SWF；
+- 把静态调用覆盖当成运行时 profile；
+- 用“数学函数”标签替代边界、顺序、别名和随机状态验证；
+- 一次性把整类、整条战斗链或整套调度器改写成 PCode；
+- 仅凭 `publish_done.marker` 或旧 trace 声称编译、性能或回归通过。
+
+## 3. 证据口径
+
+### 3.1 事实、推测与待测
+
+本文使用三种口径：
+
+- **已确认**：能由当前代码、测试、已有静态产物或 canonical 文档直接证明；
+- **成本推测**：依据 AVM1 已有基准与调用链提出，但尚无当前场景 profile；
+- **待测**：必须在生产 `Adobe Flash Player 20.exe` standalone、代表场景和相同输入下取得新证据后才能下结论。
+
+热点等级不使用“看起来算法复杂”作为证据。本文的最高等级仍只是“代码明确位于每帧/每实体链上”，没有任何候选达到“已在当前代表场景测得占比”的等级。
+
+### 3.2 静态普查方法
+
+普查覆盖了 `scripts/` 下约 1,500 个非明显测试、benchmark、probe、diag 的 `.as` 文件，并沿以下路径做交叉核对：
+
+- `org.flashNight.naki`：排序、随机数、容器与选择算法；
+- `org.flashNight.neur`：定时器、自动机、输入；
+- `org.flashNight.arki`：子弹、碰撞、TargetCache、Updater、任务/成就；
+- `org.flashNight.gesh`：深度与空间相关基础设施；
+- `scripts/引擎`、`scripts/逻辑`、`scripts/通信`：全局绑定与真实帧入口；
+- 对应 `*Test.as`、`tools/cf7-sort-fuzzer` 和已有设计文档。
+
+本轮统一过滤掉路径含 `unused` / `优化随笔`，以及文件名含 `Test|Benchmark|Tester|Probe|Diag` 的 `.as`。类覆盖按裸标识统计，仍可能含 import 或注释，只能说明采用面；全局函数另用 `name\s*\(` 统计直接调用，不能把绑定、前缀命中或注释当调用。本轮得到的代表性数据为：
+
+| 标识 | 同一过滤口径下的静态结果 | 只能说明什么 |
+|---|---:|---|
+| `TimSort` | 裸标识 40 次 / 19 个文件 | 排序基础设施已有多处采用 |
+| `LinearCongruentialEngine` | 裸标识 101 次 / 36 个文件 | LCG 是主随机实现，不等于每帧耗时已测得 |
+| `EnhancedCooldownWheel` | 裸标识 101 次 / 20 个文件 | 定时器采用广，但回调成本可能占主导 |
+| `SpatialHashGrid` | 2 个直接 class 文件；现役业务只找到 1 条 2D API 条件调用 | 普通 1D TargetCache/BQP 覆盖不能归因给 grid |
+| `BulletQueueProcessor` | 裸标识覆盖 22 个文件 | 子弹链采用广，不能推导某个叶子占比 |
+| `_root.随机整数(` | 42 次 / 8 个文件 | 直接调用存在 |
+| `_root.basic_random(` | 21 次 / 7 个文件 | 直接调用存在 |
+| `_root.成功率(` | 29 次 / 16 个文件 | 直接调用存在 |
+| `_root.随机浮点(` | 0 次 / 0 个文件 | 裸 token 的绑定/前缀命中不是调用 |
+
+恢复施工时，应重跑同类搜索，但不得依赖这些数字做最终优先级。
+
+### 3.3 已有 AVM1 成本基线
+
+项目的 [`agentsDoc/as2-performance.md`](../agentsDoc/as2-performance.md) 已汇总 165 项基准及 `BytecodeProbe`。其中最能影响候选判断的量级是：
+
+| 操作 | 已有量级 | 候选筛选含义 |
+|---|---:|---|
+| 局部寄存器 | 近似 0 ns | 把循环状态固定到局部/寄存器可能有效 |
+| 数组索引 | 约 35 ns | 密集数组扫描有实验价值 |
+| `_root` 访问 | 约 46 ns | 循环内重复全局解析应先缓存 |
+| 成员访问 | 约 144 ns | 动态对象字段密集时，布局常比算术更重要 |
+| 普通函数调用 | 约 485 ns | 叶子方法内联、批处理边界可能有效 |
+| 方法调用 | 约 1,340 ns | 每元素小方法尤其值得测量 |
+| `new` | 约 847 ns | 分配型算法不应只盯指令数 |
+| `arguments` | 约 1,538 ns | 通用变参 API 可能被固定参数专用路径替代 |
+
+这些数字来自既有基准，不是本轮新测结果。AS2 类型标注本身不会提供类似 JIT 的运行时优化；真正可期待的收益主要来自消除调用、作用域/成员解析、分配和不必要分支。
+
+### 3.4 当前 SWF 静态护栏
+
+本轮执行了两个只读检查：
+
+```text
+node tools/swf-function-sizes.js scripts/asLoader.swf --max 60000
+node tools/audit-as2-class-embedding.js --policy single-ownership
+```
+
+结果：现有 `asLoader.swf` 扫到 9,223 个函数，最大三个函数的 code size 为 56,646、55,697、54,271，均低于本次 60,000 门；`org.flashNight` 类归属检查为 main 0、loader 592、交集 0，通过 single-ownership。
+
+这只证明当前已有产物未越过本次静态门，不证明候选所在函数有足够余量，也不证明新字节码可编译。AVM1 `DefineFunction2.codeSize`、长跳转、常量池和 `DoInitAction` 顺序仍是硬风险；每次实验都必须重新归因到具体函数并重跑护栏。
+
+## 4. 评分模型
+
+为避免用一个伪精确总分掩盖证据缺口，本文保留四个独立维度，均为 0–5：
+
+| 维度 | 0 | 3 | 5 |
+|---|---|---|---|
+| `H` 热点可信度 | 无生产采用 | 周期性、多处调用，或每帧上游中的条件分支 | 新鲜代表场景 profile 已量化 |
+| `B` 字节码空间 | 宿主/动态成本主导 | 有可消除调用、分支或访问 | 已有 PCode A/B 证明直接收益 |
+| `O` oracle 完整度 | 无测试 | 单元 + 关键边界 | 差分/fuzz/固定向量 + 生产 trace |
+| `R` 风险，越高越差 | 纯值返回 | 状态/顺序/别名约束 | 启动、权限、巨大函数或跨系统副作用 |
+
+优先级含义：
+
+- **A**：可以先做测量或隔离双实现；
+- **B**：价值可疑但 oracle 不足，必须先补测试；
+- **C**：先做源级/API/数据布局或 profile；
+- **D**：当前停放或淘汰。
+
+## 5. 总体候选矩阵
+
+| 候选 | H | B | O | R | 当前裁决 |
+|---|---:|---:|---:|---:|---|
+| `SpatialHashGrid` 纯查询/rebuild 数值核 | 2 | 4 | 4 | 3 | C：先 profile；可作非收益型工具 PoC |
+| LCG step / fixed-range / batch | 3 | 3 | 2 | 4 | **B：先冻结序列向量** |
+| `RayCollider` slab | 3 | 3 | 4 | 3 | A：条件热路中的数学窄相 |
+| `PolygonCollider` SAT 前半段 | 3 | 3 | 4 | 4 | A/B：Ray 成功后再扩 |
+| `TimSort.sortIndirect` 固定 key | 3 | 1 | 5 | 3 | **A：工具链与测量对照组** |
+| BQP/TargetCache 有序扫描窗口 | 4 | 3 | 2 | 5 | **B：先抽纯函数与差分 oracle** |
+| `DepthManager.updateDepthBatch` | 3 | 2 | 4 | 4 | C：先拆算术与原生调用占比 |
+| `CooldownWheel.tick` / Enhanced wrapper | 3 | 1 | 4 | 4 | C：回调/API 形状优先于 PCode |
+| `UnitUpdateWheel.tick` | 4 | 1 | 2 | 5 | C：dispatcher/MovieClip/异常路径主导 |
+| `LightObjectPool` | 3 | 1 | 3 | 2 | C：ring + bitmask 已很紧凑 |
+| `FrameTaskMinHeap` | 1 | 2 | 4 | 3 | D：heap mutation 只服务超长延迟任务 |
+| `XMLParser` 等解析器 | 2 | 2 | 3 | 2 | D：另列启动/面板 burst latency 赛道 |
+| 输入 DFA 的 AS2 本地热路 | 1 | 2 | 4 | 3 | D：生产主识别已在 V8；保留作跨端 oracle |
+| `ObjectiveEvaluator` | 1 | 2 | 4 | 4 | D：当前低频，V8 下沉也尚未开工 |
+| `SortRouter` | 0 | 2 | 4 | 1 | D：生产未采用 |
+| `ArrayPool`、`CircularQueue`、`TimSelect` 等 | 0 | 2 | 1–3 | 1–3 | D：无生产引用或仅测试/诊断 |
+
+`H=4` 表示候选 kernel 本身处在明确每帧/每实体执行路径，不因“上游函数每帧运行”就自动获得；条件分支最多记 3。本轮没有任何 `H=5`。
+
+## 6. 首批候选详审
+
+以下按系统类别展开，不代表施工优先级；实际实验顺序以 §10 为准。
+
+### 6.1 `SpatialHashGrid`：强 oracle、低生产覆盖
+
+关键文件：
+
+- [`SpatialHashGrid.as`](../scripts/类定义/org/flashNight/arki/unit/UnitComponent/Targetcache/SpatialHashGrid.as)
+- [`SortedUnitCache.as`](../scripts/类定义/org/flashNight/arki/unit/UnitComponent/Targetcache/SortedUnitCache.as)
+- [`SpatialHashGridTest.as`](../scripts/类定义/org/flashNight/arki/unit/UnitComponent/Targetcache/SpatialHashGridTest.as)
+- [`SortedUnitCache2DTest.as`](../scripts/类定义/org/flashNight/arki/unit/UnitComponent/Targetcache/SortedUnitCache2DTest.as)
+
+`SortedUnitCache` 确实支持首次 2D 查询时懒建 grid，但这不表示普通 1D TargetCache/BQP 调用会经过它。本轮在生产代码中只找到 [`电感切割刃.as`](../scripts/逻辑/装备函数/电感切割刃.as) 对 `findNearestEnemyAtPoint2D` 的一条直接业务调用，而且受超载许可、`_root.成功率`、`interval=5` 门控并传入 filter。由此只能确认 grid 有现役业务入口，不能确认它是广泛热点。
+
+值得测的原因：
+
+- `rebuildFromParallelArrays`、`queryRect`、`queryCircle`、`countCircle`、nearest 等路径是密集数值循环；
+- `_isFiniteNumber` 是很小的叶子判定，却在 rebuild 每单位和每次查询中反复作为方法调用；
+- 坐标到 cell、cell 范围裁剪、平方距离比较都可被抽成纯数组输入输出；
+- 现有测试覆盖边界包含、NaN、filter、大规模数据、并行数组 rebuild、resize 与结果槽轮换。
+
+若把它作为工具链 PoC，第一刀只能是：
+
+```text
+输入：dense units/left/right 或纯坐标数组 + grid 参数
+输出：cell 索引，或固定 filter 语义下得到的稳定 id/index 列表
+```
+
+不得第一刀替换整类。整类还承担 4 个轮换结果数组、零复制、filter、稳定顺序和 cache 生命周期；这些不是纯算术。无 filter microbenchmark 可以验证生成器，却不能证明当前唯一业务调用受益。
+
+第一步应在电感切割刃真实门控场景记录调用数和帧占比；只有占比足够，才测试内联 finite 判定、缓存 cell 常量、减少方法/成员解析。停止条件是：真实调用过稀、纯核在生产播放器中的收益不足以覆盖桥接/维护成本，或 filter/顺序/结果槽契约无法保持。
+
+### 6.2 LCG：覆盖广，但正确性门最高
+
+关键文件：
+
+- [`LinearCongruentialEngine.as`](../scripts/类定义/org/flashNight/naki/RandomNumberEngine/LinearCongruentialEngine.as)
+- [`RandomNumberEngine/README.md`](../scripts/类定义/org/flashNight/naki/RandomNumberEngine/README.md)
+- [`引擎_fs_随机数引擎.as`](../scripts/引擎/引擎_fs_随机数引擎.as)
+
+已确认事实：
+
+- 项目把 LCG 实例通过 `Delegate.create` 暴露为 `_root.basic_random`、`_root.成功率`、`_root.随机整数` 等全局入口；
+- LCG 的 7 个 helper 已把 `nextFloat()` 手工展开为单步状态转移，说明调用税此前已被识别并优化；
+- 类被明确当作 sealed leaf，子类覆盖 `nextFloat()` 会被内联 helper 静默旁路；
+- 当前全局入口和 Delegate/方法边界可能比公式本身更昂贵。
+
+因此 PoC 不是“换一个更快随机算法”，而只能是完全保持现有序列的：
+
+- 单步 `seed -> {value,nextSeed}`；
+- 固定范围整数映射；
+- 一次调用生成 N 个值并返回最终 seed 的批量路径；
+- 或在明确调用点消除重复 Delegate/方法边界。
+
+当前 oracle 不足。`PseudoRandomDistributionTest` 覆盖确定性、分布收敛和方差压缩，`GobangTest` 等处存在固定 seed 使用，但未发现覆盖 LCG 所有 helper、负值/溢出、边界范围和最终 seed 的正式固定向量套件。
+
+施工前必须先冻结：
+
+1. 多组固定 seed 的前 N 项整数与浮点 bit/字符串表示；
+2. 每个 helper 消耗几次状态；
+3. `min=max`、反向范围、负数、极大范围与 NaN/undefined 的现状；
+4. 连续调用后的最终 seed；
+5. 保存/恢复与 Delegate `this` 绑定。
+
+任何少消费或多消费一步都会改变全局游戏随机序列，属于行为破坏，即使统计分布“更好”也不能接受。
+
+### 6.3 `RayCollider` / `PolygonCollider`：数学性最纯的战斗候选
+
+关键文件位于 `scripts/类定义/org/flashNight/arki/bullet/BulletComponent/Collider/`。
+
+调用证据比单独搜索 class 名更强：`BulletQueueProcessor.processQueue` 注册在帧末链上；普通 AABB 宽相已在大循环内内联，多边形候选与射线分支仍会调用 collider 的 `checkCollision`。
+
+优先做 `RayCollider` slab：
+
+- 零分配、有限输入、分支边界清晰；
+- hit/miss、起点在内、平行、擦边、`tEntry`、NaN 都有现有测试；
+- 适合把源码版和字节码版在同一个 test runner 中逐例比较。
+
+`PolygonCollider` 的 SAT + clipping 也有高潜力，但应只在 Ray 实验成功后切前半段投影/分离轴。后半段裁剪、静态复用 `CollisionResult`、交叉类型和可重入性会显著提高风险。
+
+普通 `AABBCollider.checkCollision` 不宜作为主 PoC：最热的 BQP 宽相已经在调用点手工内联，优化 class 方法本身可能触达不到真正热点。
+
+### 6.4 `TimSort.sortIndirect`：最强对照，不是最大收益承诺
+
+关键文件：
+
+- [`TimSort.as`](../scripts/类定义/org/flashNight/naki/Sort/TimSort.as)
+- [`TimSortTest.as`](../scripts/类定义/org/flashNight/naki/Sort/TimSortTest.as)
+- [`tools/cf7-sort-fuzzer`](../tools/cf7-sort-fuzzer/)
+
+生产调用覆盖 TargetCache、BulletQueue、ArrayInventory 和多种树结构。现有实现已经包含：
+
+- 预提取 key 的 `sortIndirect`；
+- null comparator 内联；
+- 静态 workspace 与清理阈值；
+- StoreRegister / PCode 宏、循环展开、缓存和重入 fallback；
+- 稳定性、分布、间接排序等丰富测试；
+- TS fuzzer 与 Flash runner 资产。
+
+因此它是最适合回答“工具是否正确、测量是否稳定、PCode 是否真的比现有源码好”的对照组，但也是边际空间可能最低的候选。首个实验应限制在固定数值 key、固定规模分布，不重写整个 TimSort，也不移除重入 fallback。
+
+如果同一输入、同一 SWF、同一 Player 下仍无法得到稳定可重复的差异，应停止扩大字节码计划，先修测量体系。
+
+### 6.5 BQP / TargetCache 有序扫描窗口：高价值、高风险
+
+关键文件：
+
+- [`BulletQueueProcessor.as`](../scripts/类定义/org/flashNight/arki/bullet/BulletComponent/Queue/BulletQueueProcessor.as)
+- [`BulletQueue.as`](../scripts/类定义/org/flashNight/arki/bullet/BulletComponent/Queue/BulletQueue.as)
+- [`SortedUnitCache.as`](../scripts/类定义/org/flashNight/arki/unit/UnitComponent/Targetcache/SortedUnitCache.as)
+
+`BulletQueueProcessor` 是明确的每帧战斗核心，且已经做了排序、预取、四路展开、宽相内联与静态 scratch 复用。它的价值很高，但整个 `processQueue` 同时包含阵营选择、cache 刷新、命中顺序、碰撞类型、伤害副作用和对象复用；整段改写会同时触碰 64 KiB 函数限制、长跳转、可维护性和静默语义差异。
+
+可接受的 PoC 只有一个很小的纯核：
+
+```text
+输入：有序 left/right key 数组 + bullet interval
+输出：[start,end) 候选窗口或稳定 candidate index 列表
+oracle：朴素 O(B*T) reference + 随机/边界差分
+```
+
+现有 `BulletQueueTest`、`RayPipelineEquivalenceTest`、`BulletSettlementTest` 只覆盖链路的一部分，尚不足以证明 broad-phase 全等价。应先写 reference 和 fuzz，再考虑任何字节码实现。
+
+## 7. 第二梯队：先 profile 或先改 API
+
+### 7.1 `DepthManager`
+
+`updateDepthBatch` 已把约 50 次方法边界收敛为一次批处理，测试也较完整。待确认的关键不是深度公式能否少几条 action，而是原生 `MovieClip.swapDepths`、MovieClip 字段访问和排序/冲突处理各占多少。先把“只算 depth”与“实际 swap”分别计时；只有算术段占比足够才进入字节码实验。
+
+### 7.2 Cooldown / Update wheels
+
+`CooldownWheel.tick` 已很紧凑；`EnhancedCooldownWheel` 的成本更可能来自节点对象、闭包与 `callback.apply(null,args)`。若 profile 证实，应先增加零参数/固定参数专用 API，而不是改写整类。
+
+`UnitUpdateWheel` 虽每帧执行，但路径含 dispatcher、MovieClip/字典、`try/catch`、splice 和 updater 副作用。它适合做事件/API/数据布局优化，不适合作为首批数学 PCode。
+
+### 7.3 对象池
+
+`LightObjectPool` 已使用 ring + bitmask，字节码边际很小。通用 `ObjectPool` 的 `apply/slice` 可能昂贵，但生产覆盖较窄；固定构造参数 API 比手写 action 更容易获得可维护收益。
+
+## 8. 暂缓与淘汰理由
+
+| 类别 | 代表对象 | 暂缓/淘汰理由 |
+|---|---|---|
+| 无生产采用 | `SortRouter`、`ArrayPool`、`CircularQueue`、`TimSelect` | 测试或诊断存在不等于值得优化 |
+| 低频特殊结构 | `FrameTaskMinHeap`、`PriorityQueue` | heap 只承接约 60 分钟以上任务；PriorityQueue 主要服务 Huffman |
+| 冷路径算法 | `AStarGrid`、`AdvancedMatrix`、树类 | fallback、工具或库存/UI 操作；先 profile |
+| 加载型 parser | XML/TOML/FNTL/Pratt/Eval/LiteJSON | burst latency；字符串、native parse、递归对象与分配占主导 |
+| 非主运行路径 | AS2 `InputSampler` / DFA | 当前生产由 Launcher V8 做主识别，AS2 保留配置、执行和 fallback |
+| 当前低负载 | `ObjectiveEvaluator` | 任务/成就扫描为低频，既有设计也明确 V8 lowering 尚未启动 |
+| 随机同族 | Mersenne Twister、PCG | 当前生产直接采用弱；先证明调用场景 |
+| 副作用 updater | `HitUpdater`、伤害/状态 handler | `_root`、MovieClip、dispatcher、shield/UI 和 handler 调用主导 |
+
+这些不是永久否决。只有出现新的生产采用、帧 profile 或明确启动/面板延迟目标时才重新评级。
+
+## 9. Oracle 完整度与缺口
+
+| 候选 | 已有资产 | 仍缺什么 |
+|---|---|---|
+| Spatial grid | `SpatialHashGridTest`、`SortedUnitCacheTest`、`SortedUnitCache2DTest`；边界、NaN、filter、resize、slot rotation | 与朴素 reference 的随机差分；生产规模固定 corpus |
+| LCG | 分布/确定性相关测试、若干固定 seed 使用 | 正式 seed→序列向量、helper 消耗数、最终 seed、异常输入现状 |
+| Ray/Polygon | Collider suite、Ray/BandRay tests、退化/擦边/NaN/性能 | 源码/PCode 同输入逐 bit/字段差分；复用结果别名与重入 |
+| TimSort | `TimSortTest`、稳定性、间接排序、`cf7-sort-fuzzer` | 固定 standalone Player/机器下可重复的 A/B protocol；重入路径语料 |
+| BQP window | BulletQueue、Ray pipeline、settlement 局部测试 | 朴素全配对 reference、随机窗口 fuzz、稳定候选/命中顺序 |
+
+本轮没有执行这些 Flash 测试。表中的“已有”表示测试代码存在，不表示当前基线刚刚跑绿。
+
+## 10. 恢复施工时的 5 个实验切片
+
+### 实验 1：TimSort 对照
+
+- 固定数值 key 与 4–6 种规模/分布；
+- 使用现有 fuzzer 语料和稳定性判定；
+- 只替换一个明确函数或宏；
+- 目标是验证工具与统计协议，不预设必须合入。
+
+### 实验 2：LCG 固定向量与 batch
+
+- 第一提交只增加 oracle，不做性能改动；
+- 冻结多个 seed、所有 helper、最终 seed；
+- 第二步才比较单次 Delegate、直接方法和 batch；
+- 保持算法、状态消费次数和存档兼容完全不变。
+
+### 实验 3：有序窗口纯核
+
+- 先从 BQP/TargetCache 抽出无副作用 reference；
+- 用朴素全配对结果作为 oracle；
+- 冻结候选顺序和重复元素语义；
+- 未建立完整差分前禁止接回 `processQueue`。
+
+### 实验 4：Ray slab
+
+- 只实现 Ray-vs-AABB slab；
+- 使用 hit/miss/inside/parallel/graze/NaN 固定集和随机差分；
+- 把碰撞结果构造/复用排除在算术计时之外；
+- 成功后才评估 Polygon SAT 前半段。
+
+### 实验 5：Spatial 场景 profile / 可选 PoC
+
+- 先量化电感切割刃门控后的真实调用频率与帧占比；
+- 若只需要工具 PoC，从现有测试生成固定 dense-array corpus 并同帧双跑；
+- 生产实验必须保持实际 filter、结果顺序、边界包含和 NaN；
+- 不触碰结果槽轮换和 cache 生命周期；无场景收益即停止。
+
+## 11. 统一施工门槛
+
+任何一个实验接回生产前都必须满足：
+
+1. **测量门**：新鲜 `Adobe Flash Player 20.exe` standalone 代表场景 profile 证明该核值得优化；不能只用 microbenchmark。
+2. **语义门**：源码 reference 与候选实现对固定向量、边界、随机 corpus 全等；NaN、null、undefined、稀疏数组和原型相关语义按候选实际输入显式处理。
+3. **统计门**：warm-up、批次数、顺序互换、median/p95 和噪声阈值固定；同时报告绝对帧时间与相对变化。
+4. **编译门**：仍由 Flash CS6 GUI 产生实际 SWF；只有新鲜 Output/trace 或 IDE 复核才能声称编译通过。
+5. **字节码门**：重新检查函数 code size、长跳转、栈/寄存器、常量池和 `DoInitAction`/类初始化顺序。
+6. **归属门**：重跑 `audit-as2-class-embedding --policy single-ownership`，不得让 main 与 asLoader 重复持有类。
+7. **可维护门**：PCode 必须局限在有命名、有 reference、有注释契约的小核；保留可读源码 fallback，禁止整类黑盒化。
+8. **回滚门**：一个开关或一次局部 revert 能恢复源码路径，不改变存档、协议或随机序列。
+
+若候选只在 microbenchmark 中变快、代表场景无收益，裁决应为“不合入”，而不是继续扩大改写范围。
+
+## 12. 重新接手施工的入口
+
+未来恢复时，建议按以下顺序读取：
+
+1. 本备忘；
+2. [`agentsDoc/as2-performance.md`](../agentsDoc/as2-performance.md)；
+3. [`agentsDoc/as2-anti-hallucination.md`](../agentsDoc/as2-anti-hallucination.md)；
+4. [`agentsDoc/testing-guide.md`](../agentsDoc/testing-guide.md)；
+5. 目标 class、对应测试和真实上游调用点；
+6. 若要编译，再读 [`scripts/FlashCS6自动化编译.md`](../scripts/FlashCS6自动化编译.md)。
+
+恢复施工前先重查：代码基线、候选生产采用、已有 SWF 函数尺寸、类归属、测试入口和代表场景。若任一调用链已迁到 V8/WebView 或被新的 facade 替换，本备忘的热点评级自动过期。
+
+## 13. 最终裁决
+
+第一类思路合理，但应理解为“为极少数封闭 kernel 建立一条受控的字节码优化能力”，而不是“尽量多把基础设施改写为字节码”。
+
+当前最值得投资的是：先把 profile、reference、差分和回滚做成模板，用 TimSort 验证工具与统计协议，再用 Ray 验证数学叶子；LCG 与 BQP 只有在补齐序列/顺序 oracle 后才进入。Spatial 只在真实武器场景有占比时作为性能候选，否则至多保留作强-oracle 工具样本。只要工具成本不能被多次复用，或代表场景收益不稳定，就应把结果保留为研究资产而停止扩张。

--- a/docs/TS到AS2编译基建可行性备忘-2026-07-18.md
+++ b/docs/TS到AS2编译基建可行性备忘-2026-07-18.md
@@ -1,0 +1,386 @@
+# TS 到 AS2 编译基建可行性备忘（2026-07-18）
+
+> **文档角色**：只读可行性研究、架构边界记录与未来开工交接；非 canonical 规范。
+>
+> **状态**：**仅研究，工具链尚未启动**。没有建立 fork、编译器、IR、代码生成器或生产接入。
+>
+> **代码基线**：`fd6e3e6e424d69319e867a5d0dd31887f38df664`。
+>
+> **外部生态快照**：2026-07-18；Rascal、TypeScript 和 LLVM 等信息具有时效性，恢复施工时必须重查。
+>
+> **边界**：本轮未编译 AS2、未生成或修改 SWF、未验证 MTASC/Rascal 对本项目产物的兼容性。本文的生产语义 ABI 固定指向仓库根目录 `Adobe Flash Player 20.exe` standalone + 待实验目标的明确 SWF header/target version；CS6 Test Movie 只用于编译/smoke，不能替代生产播放器差分。
+>
+> **关联研究**：当前值得做字节码 A/B 的 AS2 kernel 见 [`AS2字节码优化候选普查备忘-2026-07-18.md`](AS2字节码优化候选普查备忘-2026-07-18.md)。
+
+## 1. 决策摘要
+
+“允许用强类型 TS 表达一部分仍需落到 AS2 的逻辑”有长期工程价值，但它不等于“让任意 TS 自动变成 AS2”，也不应以 LLVM 为第一层抽象。
+
+结合当前项目，最有前景的路线是：
+
+```text
+严格 TS 子集
+    ↓ TypeScript AST + 类型检查 + 禁止语义诊断
+CF7 Portable IR
+    ├── IR 解释器：语义 oracle
+    ├── JS backend：Node 快速 QA + Launcher/ClearScript 集成
+    └── 可读 AS2 source backend → Flash CS6：第一生产路径
+                              └── Rascal/PCode：后续可选实验后端
+```
+
+当前不建议开工。原因不是前景差，而是项目中的业务 authority 与 UI 迁移仍在快速演进；编译器只有在多个稳定模块需要双端实现时才会摊薄成本。现在适合冻结问题、子集、样本、路线和启动门槛，等业务稳定窗口再复核。
+
+路线裁决：
+
+- **生成可读 AS2，再由 CS6 编译**：近期最可行，难度中高；
+- **Rascal/PCode**：值得保留为第二后端研究，难度高，当前成熟度不足以替代生产链；
+- **MTASC fork**：适合做历史参考和行为 oracle，不建议作为默认主线；
+- **LLVM IR → AVM1**：当前难度极高、抽象错位、ROI 很差，暂不投入。
+
+## 2. 先澄清目标
+
+这项基建若未来启动，合理目标是：
+
+1. 让封闭、确定、可双端验证的规则或数值 kernel 用一份强类型源描述；
+2. 生成可审阅 AS2，继续接入现有 asLoader / Flash CS6 资产链；
+3. 同一语义先在 Node 跑快速测试，再在 Launcher/ClearScript `V8ScriptEngine` 跑生产宿主集成，并在 `Adobe Flash Player 20.exe` standalone 跑最终 AS2 差分；
+4. 新增业务若确实必须先落 AS2，尽量不把算法永久锁死在动态 AS2 源码里；
+5. 为逐步迁到 TS/V8 的模块保留同源 oracle，而不是一次性重写全部 authority。
+
+不合理目标包括：
+
+- 编译任意 TypeScript/JavaScript 到 AVM1；
+- 自动迁移 MovieClip、时间轴、`_root`、存档提交、DOM、WebView2 或 Win32 代码；
+- 让 TS 类型系统自动抹平 JS 与 AS2 的运行时差异；
+- 第一阶段替换 Flash CS6 或重做 SWF linker；
+- 把 V8 变成新的游戏状态总 authority；
+- 因为能生成 AS2，就鼓励继续扩大必须长期存在的 AS2 业务面。
+
+## 3. 当前项目的真实 authority 边界
+
+### 3.1 分层结论
+
+| 层 | 当前 authority | 不是它的职责 |
+|---|---|---|
+| AS2 / Flash | 运行中的游戏业务状态、战斗、MovieClip/时间轴、关卡与解锁复核、任务/成就、背包/货币、token 后的最终业务提交和副作用 | 不应承担 Web 布局、Host 窗口生命周期或启动前存档决议 |
+| C# Guardian Host | XMLSocket/Panel 协议、可信路由、panel 实例与 open/close、暂停、输入盾、WebView2 生命周期、V8 宿主，以及启动前存档决议、`<projectRoot>/saves/` 与 shadow/bootstrap 边界 | 不应重新实现一般游戏规则或绕过 AS2 commit |
+| WebView2 / JS | 展示、筛选、布局、交互意图、局部 UI 状态与只读投影 | 禁用按钮不是安全边界；不能直接写游戏状态 |
+| ClearScript V8 / TS | 当前只有伤害数字 overlay 与搓招识别两个窄域；由 Flash 帧消息驱动 | 不是通用业务运行时，也没有存档/物品提交 authority |
+
+canonical 边界见 [`agentsDoc/architecture.md`](../agentsDoc/architecture.md)、[`agentsDoc/as2-web-panel-migration.md`](../agentsDoc/as2-web-panel-migration.md) 和 [`docs/tech-stack-rationalization.md`](tech-stack-rationalization.md)。
+
+### 3.2 AS2 authority 的代表证据
+
+选关 Web 可以显示“已锁定”，但 AS2 的 [`StageSelectPanelService.as`](../scripts/类定义/org/flashNight/arki/stageSelect/StageSelectPanelService.as) 会在 snapshot 现算解锁/挑战/任务提示，并在 `enter` 时再次验证入口种类、难度、解锁和配置后执行转场副作用。
+
+合成 Web 的 preview 只发送 `category + recipeIndex + craftCount`，commit 只发送 opaque token；recipe 定义与最终计划从不由 Web 提交。[`CraftingPanelService.as`](../scripts/类定义/org/flashNight/arki/item/CraftingPanelService.as) 在 AS2 侧解析 recipe、重算计划、备份容器、扣料、交付、扣币并在失败时回滚。编译共享可以抽出纯价格/需求公式，但不能把 recipe authority、token、容器引用和原子提交悄悄移到 Web/V8。
+
+### 3.3 Host 与 Web 的边界
+
+C# 的 `TaskRegistry`、`PanelBridge`、`LauncherCommandRouter` 和 `PanelHostController` 负责可信路由、参数白名单、active panel、实例号、暂停/ESC/焦点与 WebView 生命周期。它们是协议和窗口状态机的 authority，不是一般游戏规则 authority。
+
+`launcher/web/modules/stage-select-data.js` 是 **Web 选关布局、稳定 id 和入口清单** 的运行时 SOT；它不是关卡配置、解锁条件和进关事务的全局 SOT。未来文档必须保留这个限定，不能因“唯一 SOT”字样把业务 authority 扩到 Web。
+
+### 3.4 现有 V8 不是通用迁移平台
+
+当前实现的关键事实：
+
+- [`launcher/src/V8/V8Runtime.cs`](../launcher/src/V8/V8Runtime.cs) 只有一个持久 `V8ScriptEngine`；
+- 所有访问经过一个 `_lock`；
+- 只加载 `dist/hit-number-bundle.js`；
+- API 面只有 `HitNumber` 与 `GameInput`；
+- [`FrameTask.cs`](../launcher/src/Tasks/FrameTask.cs) 由 Flash 帧消息同步调用 camera、spawn、tick 和 input；
+- [`launcher/scripts/tsconfig.json`](../launcher/scripts/tsconfig.json) 使用 `module: none` + 单一 `outFile`；
+- 当前仓库锁定 TypeScript `~5.8.2` 且开启 `strict`。
+
+GameInput 需要精确描述：V8 已是生产主识别器，AS2 把按键与 DFA 配置传入，Launcher 回 `K` 命令；AS2 仍拥有 DFA 配置加载/编译/序列化、`K` 结果消费、命令执行与业务 guard，并保留各招式的同帧检测兜底，但没有第二套完整本地 DFA 等价 failover。因此它不是“V8 只做 advisory”，也不是“V8 接管输入业务 authority”，而是 **V8 主识别、AS2 配置与执行 authority**。
+
+一个 engine + 一个 lock + XMLSocket 同步帧通道意味着：未来不能把长扫描或大批业务都塞进当前 bundle，然后声称 V8 已自然具备多业务并行能力。新增 compiler backend 与扩大 V8 runtime 是两个不同决策。
+
+## 4. 代表性业务样本
+
+| 样本 | 当前形态 | 可移植性 | 研究价值 |
+|---|---|---|---|
+| 关卡解锁谓词 | AS2 从进度/关卡配置读取并判定 | **高，先抽 adapter** | 显式 `stageInfo + progress -> boolean` 后适合共享 |
+| 任务/成就 objective | JSON 声明 + AS2 `ObjectiveEvaluator` 读 `_root`/ItemUtil | **中高** | 采集层留双端 adapter，纯谓词可进 portable IR |
+| 搓招 DFA | AS2 与 TS 已有人工作出的对应实现；V8 主识别 | **高** | 最好的双 backend 差分样本，也最能暴露手工镜像漂移 |
+| TimSort / LCG / 空间查询 | AS2 数值基础设施 | **高到中高** | 适合 strict subset、性能与语义 oracle |
+| 合成 plan 算术 | AS2 计划/提交一体，Web 只预览/意图 | **局部中** | 倍率、需求缩放可共享；token/回滚/commit 禁止迁移 |
+| Stage Select 整体 | Web 布局 + AS2 snapshot/enter + Host 生命周期 | **拆分后才可移植** | 只共享解锁/选择纯规则，不能“编译整个面板” |
+| 伤害数字 overlay | TS/V8 + C# overlay 专属 | **算法中、业务收益低** | 已无 AS2 双端需求，不应为了展示 compiler 而反向生成 |
+| `HitUpdater` / BQP 整体 | MovieClip、dispatcher、缓存、命中副作用密集 | **极低** | 只能抽数学叶子，不能翻译整条战斗链 |
+| PanelHost 状态机 | C# / Win32 / WebView2 生命周期 | **不适用** | Host 专属，不属于 TS→AS2 问题 |
+
+[`docs/任务成就-判定层共享-设计-2026-06-11.md`](任务成就-判定层共享-设计-2026-06-11.md) 已明确：任务/成就 V8 下沉仍是未开工草案，当前 10 秒级扫描不是热点；只有条目和触发密度增长、声明层稳定后才值得做。这个现成决策与本备忘一致。
+
+## 5. 为什么不能直接“TS 编译成 AS2”
+
+TypeScript 的类型用于静态检查，运行时仍遵循 JavaScript 语义，类型会被擦除。[TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/typescript-from-scratch) 明确把 TS 描述为带类型检查的 JavaScript。因此 `strict: true` 能减少业务错误，却不会自动给出 AS2 等价语义。
+
+项目已有的 [`agentsDoc/as2-anti-hallucination.md`](../agentsDoc/as2-anti-hallucination.md) 记录了多项真实差异：
+
+- `Number(null)`、`Number("")`、`Number(" ")` 在项目 AS2/Player 行为与现代 JS 不同；
+- NaN 的相等和 `<=` / `>=` 行为存在 AVM1 特例；
+- `undefined`、null、原型链和动态属性查找有版本与对象形态差异；
+- AS2 类型标注主要是编译期约束，不是现代 VM 的优化类型；
+- 函数调用、`this`、scope chain 和 `CallFunction` / `CallMethod` 的 lowering 细节会直接改变行为。
+
+如果先让 `tsc` 输出普通 JS，再解析 JS 文本翻译，类型信息和许多语义意图已经丢失；如果允许任意 JS 对象模型，就必须在 AVM1 上重新实现相当大一部分 JS runtime。正确入口应是经过 TypeChecker 的 TS AST，并在 lowering 前拒绝不属于子集的语义。
+
+## 6. 建议的 Portable TS v0 子集
+
+### 6.1 允许项
+
+首版只允许能被封闭解释的函数：
+
+- 顶层纯函数，或所有可变状态都通过显式参数输入并在返回值中输出；
+- `number`、`boolean`、有限用途的 `string`；
+- 明确的 `Int32` / `UInt32` / `FiniteNumber` 品牌类型或编译器内建类型；
+- dense、同构、仅数字索引的 primitive array；
+- sealed、字段固定、无原型行为的 record；
+- `if`、`switch`、`for`、`while`、早返回；
+- 首版非递归、无互递归；
+- 显式 `ToNumber`、`ToInt32`、`floor`、位运算、数值比较；
+- 明确列入白名单且双端定义一致的 `Math` intrinsic；
+- 确定性函数；随机、时间和 IO 必须通过显式 context/state 输入；
+- 数组或 record 的 mutation 只有在参数/返回契约中明确声明时允许。
+
+这些类型只是编译期承诺，不能信任跨运行时输入自动满足。任何来自 AS2、JSON、XMLSocket 或 Host 的值都必须先经过生成或共享的 boundary adapter：校验/规范化整数范围与 wrap policy、finite、dense array 是否有 holes、元素类型/长度，以及 record 的必需字段、额外字段 policy 和字符串编码。adapter 之外的 portable core 才能把 `UInt32`、`FiniteNumber`、dense array 与 sealed record 当作 invariant。
+
+建议的函数形态：
+
+```ts
+type StepResult = { value: number; nextState: UInt32 };
+
+function lcgStep(state: UInt32): StepResult;
+function queryCircle(input: DenseUnitArrays, query: Circle): DenseIntArray;
+function objectiveSatisfied(raw: number, target: number): boolean;
+```
+
+关键不是语法像不像 TS，而是所有效果、转换、状态推进和容器形状都能进入 IR 契约。
+
+### 6.2 首版禁止项
+
+| 禁止语义 | 原因 |
+|---|---|
+| `any`、`unknown`、unchecked type assertion | 会让子集验证失去意义 |
+| 隐式 `+`/比较/真假值转换 | JS 与 AS2 coercion 不足以假设等价 |
+| portable core 中的原生 null/undefined | 改用显式 tagged `Option`；避免版本和原型差异 |
+| sparse array、holes、动态长度副作用 | 枚举、length、undefined 与删除语义复杂 |
+| 字符串动态属性、`in`、`delete`、`__proto__` | 需要对象模型与原型查找 |
+| class 继承、monkey patch、动态 `this`、`super` | AS2/JS 调用和原型语义难以静态等价 |
+| closure 捕获可变状态 | scope、生命周期、寄存器与调用语义复杂 |
+| `eval`、`with`、动态模块副作用 | 无法封闭作用域和效果 |
+| `try/catch/throw` | 异常模型与控制流/性能成本不适合作为 v0 |
+| async、Promise、generator | AVM1 无对应调度模型 |
+| Date、`Math.random`、JSON、XML、网络 | 宿主/状态/解析语义不同 |
+| Map、Set、RegExp、Symbol、BigInt | 缺少直接、稳定的 AS2 对应语义 |
+| rest/spread、解构、默认参数 | 首版先避免隐式分配和调用 lowering |
+| DOM、MovieClip、`_root`、WebView/Host API | 这些是 adapter/authority 边界，不属于 portable core |
+
+禁止项应由工具给出可定位诊断，而不是“尽量生成后看能否运行”。
+
+## 7. CF7 Portable IR 的必要性
+
+IR 不应照搬 LLVM，也不应只是打印 AS2 AST。它需要承载项目真正要验证的语义，例如：
+
+- `NumberAdd` 与 `StringConcat` 分离；
+- `ToNumber`、`ToInt32`、`UInt32Wrap` 明确；
+- `NumberEq`、有限数比较、NaN policy 明确；
+- dense array load/store 与 bounds policy 明确；
+- fixed record field 不经动态字符串查找；
+- state transition 与 effect summary 明确；
+- portable intrinsic 有版本化清单。
+
+第一实现应是 IR 解释器，不是 PCode emitter。解释器提供小而稳定的语义 oracle；随后 Node 快速 backend、Launcher/ClearScript V8 集成和 AS2 source backend 都对同一向量作差分。如果 IR interpreter、Node、生产 ClearScript 和 `Adobe Flash Player 20.exe` standalone 不能稳定一致，就不应继续投资直接字节码后端。Node 只负责快速 QA，不能代替单 engine、单 lock、固定 bundle 的真实 ClearScript 宿主。
+
+## 8. 三条编译路线比较
+
+| 路线 | 与现有资产链匹配 | 主要难点 | 难度 | 当前建议 |
+|---|---|---|---|---|
+| TS subset → CF7 IR → 可读 AS2 → CS6 | 高 | 子集语义、代码大小、可读性、CS6 quirks、GUI 编译 | 中高 | **第一生产路线** |
+| TS subset / IR → Rascal 或 PCode | 中，尚未证明 asLoader 集成 | 编译正确性、SWF linking、frame/类归属/初始化顺序 | 高 | 第二阶段、固定版本实验 |
+| TS/其他语言 → LLVM IR → AVM1 | 低 | JS runtime、栈机 backend、ABI、linker、资产整合 | 极高 | **暂不做** |
+
+### 8.1 生成 AS2 source → CS6
+
+优势：
+
+- 保留现有 Flash CS6 作为最终 AVM1 生成与资产集成 authority；
+- 生成物可审阅、可 diff、可被现有 include/asLoader 结构消费；
+- 第一阶段不用同时实现 SWF linker、frame 注入和 `DoInitAction`；
+- 遇到问题可回退到手写 AS2 reference；
+- 更容易遵守项目现有 `.as` BOM、类单一归属和编译验证规则。
+
+代价：
+
+- CS6 仍是 GUI/非完全 headless 门；
+- AS2 compiler 自身的动态语义、函数尺寸与初始化顺序限制仍在；
+- 生成代码必须保持可读且能映射回 TS 源位置；
+- 不能把所有 IR optimization 都假设为 CS6 会保留或正确降低。
+
+首个 backend 应偏保守：稳定变量命名、结构化控制流、显式 helper、source map/manifest、函数尺寸预估和 hash；不要为了“像编译器”立刻生成难审的巨型 AS2。
+
+### 8.2 Rascal / PCode
+
+[Rascal](https://github.com/Dinnerbone/Rascal) 是 Rust 实现的 AS2 compiler/linker，仓库采用 MIT/Apache-2.0，提供 loose script/class、PCode 与 programmatic builder；本轮外部快照看到的最新 release 为 [0.3.5（2026-06-10）](https://github.com/Dinnerbone/Rascal/releases/tag/rascal-v0.3.5)。Ruffle 已合入 Rascal 以程序化构建 AVM1 测试，包括 PCode 测试，[Ruffle PR #23513](https://github.com/ruffle-rs/ruffle/pull/23513) 证明它有真实集成价值。
+
+但“适合测试生成”不等于“可替代 CF7 生产编译链”。当前风险包括：
+
+- 仍是 0.x，API 和文档需固定 commit 后用 smoke 验证；
+- 公开 issue [#71](https://github.com/Dinnerbone/Rascal/issues/71) 记录了函数返回值立即调用时 `CallFunction` / `CallMethod` lowering 错误；
+- 还需验证 PCode parser、闭包、初始化顺序、长分支、code size、常量池和寄存器；
+- 已检查的公开接口偏向生成新 SWF，未证明能安全更新 CF7 的既有 asLoader/资产 SWF；
+- asLoader 单帧类归属、frame、`DoInitAction` 与 Flash 资产链接可能比语法编译本身更难；
+- 项目禁止手工编辑 SWF，任何集成都必须是可复现、可审计的 producer。
+
+正确策略是：先把 Rascal 当作 pinned upstream adapter、差分 oracle 或可选 backend；只有真实 blocker 无法 upstream 解决时才讨论 fork。不要一开始 fork 并承担长期同步成本。
+
+### 8.3 MTASC
+
+[MTASC](https://github.com/ncannasse/mtasc) 是历史成熟的开源 AS2 compiler，也是 Haxe 的技术前身之一。其 [man page](https://manpages.debian.org/stretch/mtasc/mtasc.1.en.html) 记录了 `-swf` 更新既有 SWF、`-out`、`-keep`、`-frame` 和 `-main` 等能力，这些对研究既有 SWF 链接行为很有价值。
+
+不建议把它作为默认 fork 基线：
+
+- 官方版本与 OCaml 构建链非常老；
+- GPL-2.0 会给 fork/分发带来额外治理问题，具体影响必须单独做许可审查，本备忘不作法律结论；
+- 旧编译器的 AS2 兼容并不自动等于当前 CF7/CS6 行为兼容；
+- 即便能更新 SWF，类保留、初始化顺序和资产 ownership 仍需项目专项测试。
+
+建议定位：历史实现参考、bytecode/linker 行为 oracle、测试语料来源，而非主生产 backend。
+
+### 8.4 LLVM IR → AVM1
+
+[LLVM LangRef](https://llvm.org/docs/LangRef.html) 描述的是强类型 SSA IR；[Writing an LLVM Backend](https://llvm.org/docs/WritingAnLLVMBackend.html) 涉及 TargetMachine、寄存器类、指令选择、legalization、调用约定和代码发射。AVM1 则是带动态对象/scope 的栈机；Adobe 的 [SWF 规范](https://www.flashrealtime.com/content/dam/Adobe/en/devnet/swf/pdf/swf_file_format_spec_v10.pdf) 还规定了 `DefineFunction2` 寄存器/`codeSize`、SI16 分支偏移、常量池和动作编码等窄限制。
+
+LLVM 不能替项目解决：
+
+- JS/AS2 值表示与 coercion；
+- object/prototype/closure/`this`；
+- sparse array、异常和标准库；
+- AVM1 stack 与 scope；
+- SWF frame、类初始化和资产链接。
+
+如果为保持普通 TS 语义而大量降低为 runtime helper，在缺少全程序可见性和效果标注时会显著限制 LLVM 优化，并增加 AVM1 调用成本；如果只支持纯数值 kernel，项目自有小 IR 更直接、可证且易映射到 AS2。只有未来同时出现多个源语言、大规模稳定数值 corpus，并证明小 IR 不够时，才值得重新评估 LLVM。
+
+## 9. TypeScript 工具链时效性
+
+仓库当前锁定 TypeScript `~5.8.2`。外部生态在 2026-07 已发生明显断层：[TypeScript 7.0 公告](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/) 说明 7.0 的新原生实现没有 programmatic API，依赖旧 compiler API 的工具需暂时使用兼容包，新的 API 计划后续提供；同一公告也把当前 bundle 使用的 `module: none` 列为 7.0 不再支持的配置。因此 compiler 研究与现役 V8 bundle 升级必须分开决策，不能顺手把工具链抬到 7.0。
+
+因此未来开工必须二选一：
+
+1. 精确 pin 能提供稳定 compiler API 的 TypeScript 版本/兼容包，并把 AST API 纳入 toolchain lock；
+2. 等待新 API 稳定后重新做 spike。
+
+不能依赖私有 AST 内部结构，也不能把“当前 `tsc` 能编项目”误写成“未来 programmatic compiler API 已稳定”。这也是现在冻结研究、不仓促开工的理由之一。
+
+## 10. 难度与前景
+
+| 能力 | 难度 | 前景 | 说明 |
+|---|---|---|---|
+| 3–5 个纯函数的 strict subset validator | 中 | 高 | 最容易验证业务价值与诊断体验 |
+| CF7 IR + interpreter | 中高 | 高 | 是双 backend 正确性的核心资产 |
+| 可读 AS2 source emitter | 中高 | 中高 | 与当前生产链最匹配 |
+| JS emitter | 中 | 高 | 同一产物分别用于 Node 快速测试、ClearScript 集成和未来迁移 |
+| Rascal standalone corpus runner | 中 | 中高 | 很适合作差分研究 |
+| Rascal 接入 asLoader 生产资产 | 高到很高 | 未定 | linker/ownership/init 比 parser 更难 |
+| 一般 TS → AVM1 | 极高 | 低 | 会演化成 JS runtime + compiler + linker |
+| LLVM AVM1 backend | 极高 | 低 | 当前不降低主要成本 |
+
+长期前景最好的不是“新语言可以随意编到 AS2”，而是形成一个小而严格的 **双运行时规则层**：一份源、一个显式语义 IR、两个可差分 backend。它能服务任务 objective、关卡规则、输入 DFA、数值 kernel 等稳定模块；它不会替代 AS2 authority、Web UI 或 Host 生命周期代码。
+
+## 11. 正式开工条件
+
+只有以下条件同时满足，才从“研究备忘”升级为“工具链项目”：
+
+1. **真实需求**：至少 3–5 个稳定业务/基础设施样本确实需要 AS2 与 TS/V8 双端，而不是为了验证技术而反向制造需求。
+2. **业务稳定**：样本 schema、authority 和协议已稳定至少一个发布周期；UI/业务大迁移不在同一施工窗口高速变化。
+3. **子集与 ABI 冻结**：类型、数值转换、Option、dense array、record、允许 intrinsic、效果模型、禁止语义、boundary adapter、生产 `Adobe Flash Player 20.exe` standalone 与每个目标的 SWF header/target version 都有版本化规范。
+4. **诊断可用**：validator 能对真实样本给出精确拒绝原因，不靠运行时踩坑界定子集。
+5. **差分矩阵**：IR interpreter、Node 快速 backend、Launcher/ClearScript V8 集成和生成 AS2/生产 standalone Player 对固定向量一致；需要时再加 Ruffle/Rascal。
+6. **收益证据**：至少两个样本证明同源能显著减少手工双实现/迁移负债，或生产 standalone Player 中有明确性能收益。
+7. **生产护栏**：生成 manifest、源码映射、函数尺寸、长跳转、栈/寄存器、类单一 ownership 和初始化顺序均有自动门。
+8. **可回退**：生成 AS2 可读、可 review，CS6 仍是首个生产 backend；直接 PCode 失败不阻塞业务。
+9. **版本治理**：TypeScript API、Rascal/MTASC（若用）、Rust/OCaml 依赖和许可证完成 pin 与审查。
+10. **维护容量**：有明确 owner、测试预算和上游同步策略；不是一次性实验后无人维护。
+
+若只有一个纯函数需要双端，通常手写两个短实现加金向量更便宜；若样本大量落在禁区，说明抽象边界不适合，而不是应该扩大编译器到任意 TS。
+
+## 12. 恢复施工的建议阶段
+
+### R0：重做生态与边界快照
+
+- 重查 TypeScript compiler API、Rascal release/open issues、MTASC 可构建性；
+- 重查项目 authority、V8 bundle、asLoader 类归属和 Flash 编译入口；
+- 确认本备忘的代表样本仍存在且稳定。
+
+### R1：只做 corpus 与语言规范
+
+- 选关解锁谓词、Objective、DFA、一个排序/空间 kernel、一个 LCG step；
+- 写 portable / rejected 两套 TS corpus；
+- 冻结数值、Option、array、record 和 effect 语义；
+- 不生成生产 AS2。
+
+### R2：IR interpreter + JS backend
+
+- 从 typed AST lower 到 CF7 IR；
+- interpreter 作为 oracle；
+- JS backend 先跑 Node 快速测试；
+- 同一产物进入 Launcher/ClearScript harness，验证单 engine、单 lock、固定 bundle 与序列化边界；
+- 测量 validator 诊断质量和维护成本。
+
+### R3：可读 AS2 backend
+
+- 生成独立测试 class，不接生产入口；
+- 通过 Flash CS6 GUI 编译，记录目标 SWF header/target version，并在仓库 `Adobe Flash Player 20.exe` standalone 跑固定向量；Test Movie 只记编译/smoke；
+- 增加 code size、类 ownership、初始化顺序与 hash 门；
+- 证明至少两个真实样本的净收益后再考虑生产接入。
+
+### R4：Rascal/PCode 实验
+
+- 固定 commit，先跑项目 corpus；
+- 对已知 `CallFunction` / `CallMethod`、闭包、长分支、常量池和 PCode parser 做专项用例；
+- 优先 upstream 修复；
+- 只有 AS2 source backend 已稳定且直接 bytecode 有可量化价值时，才评估生产集成。
+
+LLVM 不在这条默认路线中。
+
+## 13. 停止条件
+
+出现任一情况时，应停止或缩回研究：
+
+- 真实样本大多依赖 MovieClip、`_root`、动态对象、异常或宿主 API；
+- 双端金向量仍无法表达关键 AS2/JS 语义差异；
+- 生成 AS2 比手写实现更难审、更难调试；
+- 当前 CS6/asLoader 链无法稳定承接生成 class；
+- Rascal 需要长期维护私有 linker fork 才能处理资产归属；
+- 业务协议仍频繁变化，compiler 维护持续追赶 schema；
+- 性能收益只存在于 microbenchmark，或迁移负债没有实质减少。
+
+## 14. 本轮发现的邻接文档新鲜度风险
+
+只读审计发现，选关文档与现役代码对“委托任务入口”的描述已经漂移：
+
+- [`选关界面-webview迁移路线图.md`](选关界面-webview迁移路线图.md) 与 [`选关界面-AS2入口替换交接.md`](选关界面-AS2入口替换交接.md) 仍写委托入口继续旧 Flash；
+- 当前 `StageSelectPanelService.handleEnter` 对 `entryKind == "task"` 已调用 `openWebDungeon`，并注明旧 Flash 委托面板退役。
+
+本轮没有修改这些相邻文档，因为当前任务是编译基建只读研究，且不应顺带改写既有迁移验收叙述。未来使用选关作为 compiler 样本前，应先单独核对并修复这组文档漂移；同时把 `stage-select-data.js` 的 SOT 范围限定为 Web 布局/入口/id，避免误读 authority。
+
+## 15. 最终裁决
+
+第二类思路在战略上有价值，但合理的工程命题不是“fork 一个 AS2 编译器并通过 LLVM 接所有语言”，而是：
+
+> 为项目少量、稳定、可验证的共享规则建立严格 TS 子集与小型语义 IR；先生成可读 AS2 并继续使用 CS6，后续再把 Rascal/PCode 作为可替换后端。
+
+现在等待业务稳定间隙再实现是合理的。备忘已经把未来最容易重复浪费时间的研究——authority 边界、代表样本、语言禁区、三路线成本、外部工具成熟度和开工条件——冻结下来；在门槛未满足前，状态始终是 **研究完成，工具链未启动**。
+
+## 16. 外部参考快照
+
+- [TypeScript Handbook：TS 与 JS 的关系](https://www.typescriptlang.org/docs/handbook/typescript-from-scratch)
+- [TypeScript Compiler API（历史 API 参考）](https://github.com/microsoft/TypeScript/wiki/Using-the-Compiler-API)
+- [TypeScript 7.0 公告](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/)
+- [Adobe SWF File Format Specification v10](https://www.flashrealtime.com/content/dam/Adobe/en/devnet/swf/pdf/swf_file_format_spec_v10.pdf)
+- [Rascal](https://github.com/Dinnerbone/Rascal)；[0.3.5 release](https://github.com/Dinnerbone/Rascal/releases/tag/rascal-v0.3.5)；[已知调用 lowering issue #71](https://github.com/Dinnerbone/Rascal/issues/71)
+- [Ruffle 引入 Rascal 的 PR #23513](https://github.com/ruffle-rs/ruffle/pull/23513)
+- [MTASC repository](https://github.com/ncannasse/mtasc)；[MTASC man page](https://manpages.debian.org/stretch/mtasc/mtasc.1.en.html)
+- [LLVM Language Reference](https://llvm.org/docs/LangRef.html)；[Writing an LLVM Backend](https://llvm.org/docs/WritingAnLLVMBackend.html)


### PR DESCRIPTION
## 变更

- 新增 AS2 字节码优化候选普查备忘
- 新增 TypeScript 到 AS2 编译基建可行性备忘

## 目的

沉淀后续优化与编译基建施工的候选、边界和验证思路，不改变当前运行时代码或已发布二进制。

## 验证

- `node tools/validate-doc-governance.js`
- `classify-runtime-release-state.ps1 -Mode Protected`：`protected-coherent`、`deploymentChanged=false`