### PR TITLE
fix(runtime): audit guarded admission migration

### DIFF
--- a/tools/classify-runtime-release-state.ps1
+++ b/tools/classify-runtime-release-state.ps1
@@ -214,7 +214,7 @@ function Test-Cf7InputTreeRule([string]$Path, $Rule) {
     return $true
 }
 
-function Get-Cf7NativeChangeGate([string]$BaseCommit) {
+function Get-Cf7NativeChangeGate([string]$BaseCommit, [switch]$AllowLegacyAdmissionConfig) {
     $relativePath = 'config/build/native-change-gate.v1.json'
     $blobOid = Get-Cf7RevisionBlobOid -Revision $BaseCommit -RelativePath $relativePath -Optional
     if (-not $blobOid) { return $null }
@@ -279,7 +279,6 @@ function Get-Cf7NativeChangeGate([string]$BaseCommit) {
     }
     foreach ($required in @(
         '.github/workflows/runtime-bundle-integrity.yml',
-        'config/build/main-branch-admission.v2.json',
         'config/build/native-change-gate.v1.json',
         'config/build/runtime-inputs.v2.json',
         'tools/audit-main-branch-admission.ps1',
@@ -287,6 +286,22 @@ function Get-Cf7NativeChangeGate([string]$BaseCommit) {
         'tools/resolve-runtime-trusted-base.ps1'
     )) {
         if (-not $files.ContainsKey($required)) { throw "Native change gate is missing mandatory fixed file: $required" }
+    }
+    $currentAdmissionPath = 'config/build/main-branch-admission.v2.json'
+    $legacyAdmissionPath = 'config/build/main-branch-admission.v1.json'
+    $admissionPath = $currentAdmissionPath
+    if (-not $files.ContainsKey($currentAdmissionPath)) {
+        if (-not $AllowLegacyAdmissionConfig) {
+            throw "Native change gate is missing mandatory fixed file: $currentAdmissionPath"
+        }
+        $legacyBlob = Get-Cf7RevisionBlobOid -Revision $BaseCommit -RelativePath $legacyAdmissionPath -Optional
+        $currentBlob = Get-Cf7RevisionBlobOid -Revision $BaseCommit -RelativePath $currentAdmissionPath -Optional
+        if (-not $files.ContainsKey($legacyAdmissionPath) -or -not $legacyBlob -or $currentBlob) {
+            throw 'Legacy admission compatibility requires a base commit that exclusively contains and protects config/build/main-branch-admission.v1.json.'
+        }
+        $admissionPath = $legacyAdmissionPath
+    } elseif (-not (Get-Cf7RevisionBlobOid -Revision $BaseCommit -RelativePath $currentAdmissionPath -Optional)) {
+        throw "Native change gate protects a missing mandatory fixed file: $currentAdmissionPath"
     }
     foreach ($required in @(
         '.github/actions/', '.github/workflows/', 'config/build/', 'launcher/build',
@@ -302,10 +317,11 @@ function Get-Cf7NativeChangeGate([string]$BaseCommit) {
         Basenames = $basenames
         Files = $files
         Prefixes = $prefixes.ToArray()
+        AdmissionConfigPath = $admissionPath
     }
 }
 
-function Get-Cf7FastPathProtection([string]$BaseCommit) {
+function Get-Cf7FastPathProtection([string]$BaseCommit, [switch]$AllowLegacyAdmissionConfig) {
     $descriptorPath = 'config/build/runtime-inputs.v2.json'
     $descriptorOid = Get-Cf7RevisionBlobOid -Revision $BaseCommit -RelativePath $descriptorPath -Optional
     if (-not $descriptorOid) { return $null }
@@ -325,7 +341,7 @@ function Get-Cf7FastPathProtection([string]$BaseCommit) {
             throw "Base runtime input descriptor lacks a well-formed domain: $requiredDomain"
         }
     }
-    $nativeGate = Get-Cf7NativeChangeGate -BaseCommit $BaseCommit
+    $nativeGate = Get-Cf7NativeChangeGate -BaseCommit $BaseCommit -AllowLegacyAdmissionConfig:$AllowLegacyAdmissionConfig
     if ($null -eq $nativeGate) { return $null }
 
     $fixed = New-Object 'Collections.Generic.Dictionary[string,string]' ([StringComparer]::OrdinalIgnoreCase)
@@ -415,6 +431,7 @@ function Get-Cf7FastPathProtection([string]$BaseCommit) {
         ProtectedBasenames = $nativeGate.Basenames
         GateFiles = $nativeGate.Files
         GatePrefixes = $nativeGate.Prefixes
+        AdmissionConfigPath = $nativeGate.AdmissionConfigPath
         DescriptorOid = $descriptorOid
         GateBlobOid = $nativeGate.BlobOid
     }
@@ -622,7 +639,30 @@ function Assert-Cf7NativeChangesReleaseBound([object[]]$Entries, $BaseProtection
     })
     if ($gatedWrites.Count -eq 0) { return }
     $bound = Get-Cf7IndexedReleaseBoundPaths
-    $unbound = @($gatedWrites | Where-Object { -not $bound.Contains([string]$_.Path) } | ForEach-Object { [string]$_.Path } | Sort-Object -Unique)
+    $allowedRetirements = New-Object 'Collections.Generic.HashSet[string]' ([StringComparer]::Ordinal)
+    $entriesByPath = @{}
+    foreach ($entry in $Entries) { $entriesByPath[[string]$entry.Path] = $entry }
+    $isAdmissionV1ToV2Promotion =
+        $null -ne $BaseProtection -and
+        [string]$BaseProtection.AdmissionConfigPath -ceq 'config/build/main-branch-admission.v1.json' -and
+        [string]$HeadProtection.AdmissionConfigPath -ceq 'config/build/main-branch-admission.v2.json' -and
+        [string]$entriesByPath['config/build/main-branch-admission.v1.json'].Status -ceq 'D' -and
+        [string]$entriesByPath['config/build/main-branch-admission.v2.json'].Status -ceq 'A' -and
+        [string]$entriesByPath['config/build/native-change-gate.v1.json'].Status -ceq 'M' -and
+        [string]$entriesByPath['config/build/runtime-inputs.v2.json'].Status -ceq 'M' -and
+        [string]$entriesByPath['config/build/runtime-release-consensus.json'].Status -ceq 'M' -and
+        [string]$entriesByPath['.github/CODEOWNERS'].Status -ceq 'M' -and
+        $BaseProtection.GateFiles.ContainsKey('.github/CODEOWNERS') -and
+        -not $HeadProtection.GateFiles.ContainsKey('.github/CODEOWNERS')
+    if ($isAdmissionV1ToV2Promotion) {
+        # CODEOWNERS was part of the legacy native gate and becomes advisory in v2.
+        # Allow only that exact retirement, and only alongside a changed signed consensus,
+        # which forces the complete deployment verifier chain later in this classifier.
+        [void]$allowedRetirements.Add('.github/CODEOWNERS')
+    }
+    $unbound = @($gatedWrites | Where-Object {
+        -not $bound.Contains([string]$_.Path) -and -not $allowedRetirements.Contains([string]$_.Path)
+    } | ForEach-Object { [string]$_.Path } | Sort-Object -Unique)
     if ($unbound.Count -gt 0) {
         throw "Native/runtime changes are not bound by the indexed release descriptor and cannot become green: $($unbound -join ',')"
     }
@@ -831,7 +871,7 @@ try {
         Get-Cf7RawChangedEntries -BaseCommit $admissionBaseCommit -HeadCommit $headCommit
     })
     $admissionBaseProtection = if ($admissionBaseCommit) {
-        Get-Cf7FastPathProtection -BaseCommit $admissionBaseCommit
+        Get-Cf7FastPathProtection -BaseCommit $admissionBaseCommit -AllowLegacyAdmissionConfig
     } else { $null }
     $headProtection = Get-Cf7FastPathProtection -BaseCommit $headCommit
     Assert-Cf7NativeChangesReleaseBound -Entries $admissionChangedEntries `

--- a/tools/test-runtime-release-state.ps1
+++ b/tools/test-runtime-release-state.ps1
@@ -631,6 +631,154 @@ try {
         Assert-Test ((Get-TestCalls $f).Count -eq 0) 'malformed descriptor must fail before verifiers'
     }
 
+    Run-Test 'Admission v1 to v2 transition is accepted only on the event base side' {
+        $retiredControlPath = '.github/legacy-native-control.json'
+        $setLegacyAdmission = {
+            param($Fixture, [switch]$KeepCurrentFile, [switch]$IncludeExtraRetiredControl)
+            $gatePath = Join-Path $Fixture.Root 'config\build\native-change-gate.v1.json'
+            $gate = [IO.File]::ReadAllText($gatePath, [Text.Encoding]::UTF8) | ConvertFrom-Json
+            $legacyProtectedFiles = @($gate.protectedFiles | ForEach-Object {
+                if ([string]$_ -ceq 'config/build/main-branch-admission.v2.json') {
+                    'config/build/main-branch-admission.v1.json'
+                } else { [string]$_ }
+            })
+            $legacyProtectedFiles += '.github/CODEOWNERS'
+            if ($IncludeExtraRetiredControl) { $legacyProtectedFiles += $retiredControlPath }
+            $gate.protectedFiles = $legacyProtectedFiles
+            Set-TestFile $gatePath (($gate | ConvertTo-Json -Depth 10) + "`n")
+
+            $descriptorPath = Join-Path $Fixture.Root 'config\build\runtime-inputs.v2.json'
+            $descriptor = [IO.File]::ReadAllText($descriptorPath, [Text.Encoding]::UTF8) | ConvertFrom-Json
+            $legacyPolicyFiles = @($descriptor.domains.policy.fixedFiles | ForEach-Object {
+                if ([string]$_ -ceq 'config/build/main-branch-admission.v2.json') {
+                    'config/build/main-branch-admission.v1.json'
+                } else { [string]$_ }
+            })
+            $legacyPolicyFiles += '.github/CODEOWNERS'
+            if ($IncludeExtraRetiredControl) { $legacyPolicyFiles += $retiredControlPath }
+            $descriptor.domains.policy.fixedFiles = $legacyPolicyFiles
+            Set-TestFile $descriptorPath (($descriptor | ConvertTo-Json -Depth 12) + "`n")
+
+            Copy-Item -LiteralPath (Join-Path $Fixture.Root 'config\build\main-branch-admission.v2.json') `
+                -Destination (Join-Path $Fixture.Root 'config\build\main-branch-admission.v1.json')
+            if (-not $KeepCurrentFile) {
+                Remove-Item -LiteralPath (Join-Path $Fixture.Root 'config\build\main-branch-admission.v2.json') -Force
+            }
+            Set-TestFile (Join-Path $Fixture.Root '.github\CODEOWNERS') '* @legacy-owner'
+            if ($IncludeExtraRetiredControl) {
+                Set-TestFile (Join-Path $Fixture.Root ($retiredControlPath -replace '/','\')) '{"legacy":true}'
+            }
+        }
+        $setCurrentAdmission = {
+            param($Fixture, [switch]$ChangeConsensus)
+            $legacyAdmissionPath = Join-Path $Fixture.Root 'config\build\main-branch-admission.v1.json'
+            if (Test-Path -LiteralPath $legacyAdmissionPath) { Remove-Item -LiteralPath $legacyAdmissionPath -Force }
+            Set-TestBytes (Join-Path $Fixture.Root 'config\build\main-branch-admission.v2.json') $script:admissionConfigBytes
+            Set-TestBytes (Join-Path $Fixture.Root 'config\build\native-change-gate.v1.json') $script:nativeGateBytes
+            $descriptorPath = Join-Path $Fixture.Root 'config\build\runtime-inputs.v2.json'
+            $descriptor = [IO.File]::ReadAllText($descriptorPath, [Text.Encoding]::UTF8) | ConvertFrom-Json
+            $descriptor.domains.policy.fixedFiles = @($descriptor.domains.policy.fixedFiles | Where-Object {
+                [string]$_ -cnotin @(
+                    'config/build/main-branch-admission.v1.json',
+                    'config/build/main-branch-admission.v2.json',
+                    '.github/CODEOWNERS',
+                    $retiredControlPath
+                )
+            }) + 'config/build/main-branch-admission.v2.json'
+            Set-TestFile $descriptorPath (($descriptor | ConvertTo-Json -Depth 12) + "`n")
+            Set-TestFile (Join-Path $Fixture.Root '.github\CODEOWNERS') '# advisory only'
+            $retiredControl = Join-Path $Fixture.Root ($retiredControlPath -replace '/','\')
+            if (Test-Path -LiteralPath $retiredControl) { Set-TestFile $retiredControl '{"legacy":false}' }
+            if ($ChangeConsensus) {
+                $consensusPath = Join-Path $Fixture.Root 'config\build\runtime-release-consensus.json'
+                $consensus = [IO.File]::ReadAllText($consensusPath, [Text.Encoding]::UTF8).TrimEnd()
+                Set-TestFile $consensusPath ($consensus + "`n `n")
+            }
+        }
+
+        $passing = New-TestFixture v2
+        & $setLegacyAdmission $passing
+        [void](Invoke-TestGit $passing.Root @('add','-A'))
+        [void](Invoke-TestGit $passing.Root @('commit','-m','legacy admission baseline'))
+        $legacyBaseLines = @(Invoke-TestGit $passing.Root @('rev-parse','HEAD'))
+        $passing.Base = ([string]$legacyBaseLines[0]).Trim()
+
+        & $setCurrentAdmission $passing -ChangeConsensus
+        [void](Invoke-TestGit $passing.Root @('add','-A'))
+        [void](Invoke-TestGit $passing.Root @('commit','-m','migrate admission contract to v2'))
+        $passingResult = Invoke-Classifier $passing Audit $passing.Base
+        Assert-Test ($passingResult.ExitCode -eq 0 -and $passingResult.Output -match 'state=promoted') $passingResult.Output
+        Assert-Test ((Get-TestCalls $passing) -join ',' -eq 'v2:integrity,v2:strict,consensus:strict') `
+            'promoted admission transition must run the complete verifier chain'
+
+        $missingConsensus = New-TestFixture v2
+        & $setLegacyAdmission $missingConsensus
+        [void](Invoke-TestGit $missingConsensus.Root @('add','-A'))
+        [void](Invoke-TestGit $missingConsensus.Root @('commit','-m','legacy admission baseline'))
+        $missingConsensusBase = @(Invoke-TestGit $missingConsensus.Root @('rev-parse','HEAD'))
+        $missingConsensus.Base = ([string]$missingConsensusBase[0]).Trim()
+        & $setCurrentAdmission $missingConsensus
+        [void](Invoke-TestGit $missingConsensus.Root @('add','-A'))
+        [void](Invoke-TestGit $missingConsensus.Root @('commit','-m','unpromoted admission transition'))
+        $missingConsensusResult = Invoke-Classifier $missingConsensus Audit $missingConsensus.Base
+        Assert-Test ($missingConsensusResult.ExitCode -ne 0 -and
+            $missingConsensusResult.Output -match 'not bound.*\.github/CODEOWNERS') `
+            'CODEOWNERS retirement passed without a changed signed consensus'
+
+        $extraRetirement = New-TestFixture v2
+        & $setLegacyAdmission $extraRetirement -IncludeExtraRetiredControl
+        [void](Invoke-TestGit $extraRetirement.Root @('add','-A'))
+        [void](Invoke-TestGit $extraRetirement.Root @('commit','-m','legacy admission with extra control'))
+        $extraRetirementBase = @(Invoke-TestGit $extraRetirement.Root @('rev-parse','HEAD'))
+        $extraRetirement.Base = ([string]$extraRetirementBase[0]).Trim()
+        & $setCurrentAdmission $extraRetirement -ChangeConsensus
+        [void](Invoke-TestGit $extraRetirement.Root @('add','-A'))
+        [void](Invoke-TestGit $extraRetirement.Root @('commit','-m','attempt broad control retirement'))
+        $extraRetirementResult = Invoke-Classifier $extraRetirement Audit $extraRetirement.Base
+        Assert-Test ($extraRetirementResult.ExitCode -ne 0 -and
+            $extraRetirementResult.Output -match 'not bound.*\.github/legacy-native-control.json') `
+            'admission migration retired an arbitrary base-only native control'
+
+        $inconsistentHead = New-TestFixture v2
+        & $setLegacyAdmission $inconsistentHead
+        [void](Invoke-TestGit $inconsistentHead.Root @('add','-A'))
+        [void](Invoke-TestGit $inconsistentHead.Root @('commit','-m','legacy CODEOWNERS gate baseline'))
+        $inconsistentHeadBase = @(Invoke-TestGit $inconsistentHead.Root @('rev-parse','HEAD'))
+        $inconsistentHead.Base = ([string]$inconsistentHeadBase[0]).Trim()
+        & $setCurrentAdmission $inconsistentHead -ChangeConsensus
+        $headGatePath = Join-Path $inconsistentHead.Root 'config\build\native-change-gate.v1.json'
+        $headGate = [IO.File]::ReadAllText($headGatePath, [Text.Encoding]::UTF8) | ConvertFrom-Json
+        $headGate.protectedFiles = @($headGate.protectedFiles) + '.github/CODEOWNERS'
+        Set-TestFile $headGatePath (($headGate | ConvertTo-Json -Depth 10) + "`n")
+        [void](Invoke-TestGit $inconsistentHead.Root @('add','-A'))
+        [void](Invoke-TestGit $inconsistentHead.Root @('commit','-m','retain CODEOWNERS only in head gate'))
+        $inconsistentHeadResult = Invoke-Classifier $inconsistentHead Audit $inconsistentHead.Base
+        Assert-Test ($inconsistentHeadResult.ExitCode -ne 0 -and
+            $inconsistentHeadResult.Output -match 'not bound.*\.github/CODEOWNERS') `
+            'CODEOWNERS retirement passed while the head gate still protected it'
+
+        $downgradedHead = New-TestFixture v2
+        & $setLegacyAdmission $downgradedHead
+        [void](Invoke-TestGit $downgradedHead.Root @('add','-A'))
+        [void](Invoke-TestGit $downgradedHead.Root @('commit','-m','attempt admission downgrade'))
+        $downgradeResult = Invoke-Classifier $downgradedHead Audit $downgradedHead.Base
+        Assert-Test ($downgradeResult.ExitCode -ne 0 -and
+            $downgradeResult.Output -match 'missing mandatory fixed file: config/build/main-branch-admission.v2.json') `
+            'head-side admission downgrade unexpectedly passed'
+
+        $ambiguousBase = New-TestFixture v2
+        & $setLegacyAdmission $ambiguousBase -KeepCurrentFile
+        [void](Invoke-TestGit $ambiguousBase.Root @('add','-A'))
+        [void](Invoke-TestGit $ambiguousBase.Root @('commit','-m','ambiguous legacy admission baseline'))
+        $ambiguousBaseLines = @(Invoke-TestGit $ambiguousBase.Root @('rev-parse','HEAD'))
+        $ambiguousBase.Base = ([string]$ambiguousBaseLines[0]).Trim()
+        [void](Add-TestCommit $ambiguousBase 'docs/head.md' 'content')
+        $ambiguousResult = Invoke-Classifier $ambiguousBase Audit $ambiguousBase.Base
+        Assert-Test ($ambiguousResult.ExitCode -ne 0 -and
+            $ambiguousResult.Output -match 'Legacy admission compatibility requires') `
+            'legacy base compatibility accepted a commit that already contained v2'
+    }
+
     Run-Test 'Bound native changes use strict verification while unbound native writes fail before verifiers' {
         $cases = @(
             [pscustomobject]@{ Name='runtime'; Path='runtime/core.bin'; Content='runtime-v2'; Bound=$true },


### PR DESCRIPTION
## 根因

PR #17 同时把 admission contract 从 v1 迁到 v2。新 classifier 用 v2 的必需项读取旧 event base，因而在进入 signed consensus 校验前拒绝了合法迁移；随后旧 gate 中即将退役的 CODEOWNERS 绑定也造成同类过渡失败。

## 修复

- 仅允许 event/trusted base 在“存在并保护 v1、且不存在 v2”时读取 legacy admission contract；head 仍强制 v2。
- CODEOWNERS 退役仅在精确 v1→v2 文件替换、gate/descriptor 更新、CODEOWNERS 修改和 signed consensus 修改同时成立时允许。
- 任何其他旧控制文件、无 consensus、head 仍保护 CODEOWNERS、ambiguous base 或 v2→v1 降级继续 fail-closed。

## 验证

- PR #17 真实 `f53c541 → 1e9ccaf` 重放：`state=promoted`，完整 integrity / identity / GitHub attestation / 2-signer consensus 全绿。
- release-state suite：48/48。
- 当前修复 commit 对 main 分类：`state=source-ahead`, `verifierCount=0`。
- PowerShell AST、documentation governance、diff check：通过。